### PR TITLE
Corrected the reference to Reserve Storage when transferring values from Reserve Storage to the Primary Storage.

### DIFF
--- a/src/DDStorage.js
+++ b/src/DDStorage.js
@@ -32,7 +32,7 @@ class DDStorage {
       }
       // move persisted values
       this.ddReserveStorage.getPersistedKeys().forEach((persistedKey) => {
-        const value = this.get(persistedKey)
+        const value = this.ddReserveStorage.get(persistedKey)
         const ttl = this.ddReserveStorage.getTtl(persistedKey)
         if (value !== undefined) {
           this.storage.set(persistedKey, value, ttl)


### PR DESCRIPTION
Whilst processing through the keys for the Reserve Storage, the value retrieved to transfer to the Primary Storage is retrieved from the Primary Storage instead of the Reserve Storage.